### PR TITLE
Drop unused css

### DIFF
--- a/src/css/query-editor.css
+++ b/src/css/query-editor.css
@@ -1,3 +1,0 @@
-.generic-datasource-query-row .query-keyword {
-    width: 75px;
-}


### PR DESCRIPTION
Based on https://github.com/simPod/grafana-json-datasource/issues/8 I was investigating the css build but it is redundant so I'm dropping it for now. `.width-5` class overrides it.

	
![image](https://user-images.githubusercontent.com/327717/44936021-6c065a00-ad73-11e8-8c1c-306c9e99ed56.png)
