### PR TITLE
Improve variable interpolation

### DIFF
--- a/spec/lib/TemplateSrvStub.ts
+++ b/spec/lib/TemplateSrvStub.ts
@@ -4,6 +4,7 @@ export default class TemplateSrvStub {
   variables = [];
   templateSettings = { interpolate: /\[\[([\s\S]+?)\]\]/g };
   data = {};
+  regex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::(\w+))?}/g;
 
   // Original grafana source
   // tslint:disable-next-line:max-line-length

--- a/spec/lib/TemplateSrvStub.ts
+++ b/spec/lib/TemplateSrvStub.ts
@@ -5,6 +5,11 @@ export default class TemplateSrvStub {
   templateSettings = { interpolate: /\[\[([\s\S]+?)\]\]/g };
   data = {};
 
+  // Original grafana source
+  // tslint:disable-next-line:max-line-length
+  // https://github.com/grafana/grafana/blob/e03d702d0c14b214a57ddd5094ff756e845cdd2b/public/app/features/templating/variable.ts#L11
+  regex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::(\w+))?}/g;
+
   replace(text) {
     return template(text, this.templateSettings)(this.data);
   }

--- a/spec/lib/TemplateSrvStub.ts
+++ b/spec/lib/TemplateSrvStub.ts
@@ -4,8 +4,6 @@ export default class TemplateSrvStub {
   variables = [];
   templateSettings = { interpolate: /\[\[([\s\S]+?)\]\]/g };
   data = {};
-  regex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::(\w+))?}/g;
-
   // Original grafana source
   // tslint:disable-next-line:max-line-length
   // https://github.com/grafana/grafana/blob/e03d702d0c14b214a57ddd5094ff756e845cdd2b/public/app/features/templating/variable.ts#L11

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -126,7 +126,7 @@ export class GenericDatasource {
         // remove placeholder targets
         return target.target !== 'select metric';
       })
-      .map((target) => {
+      .map((target: any) => {
         let data = null;
 
         if (target.data !== undefined && target.data.trim() !== '') {
@@ -163,8 +163,7 @@ export class GenericDatasource {
     const replacedMatch = this.templateSrv.replace(match, options.scopedVars, 'json');
     if (
         typeof replacedMatch === 'string'
-      &&
-        replacedMatch[0] === '"'
+      && replacedMatch[0] === '"'
       && replacedMatch[replacedMatch.length - 1] === '"'
     ) {
       return JSON.parse(replacedMatch);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -129,7 +129,7 @@ export class GenericDatasource {
       .map((target) => {
         let data = null;
 
-        if (!isUndefined(target.data) && target.data.trim() !== '') {
+        if (target.data !== undefined && target.data.trim() !== '') {
           data = JSON.parse(target.data, (key, value) => {
             if (typeof value === 'string') {
               return value.replace(
@@ -162,8 +162,10 @@ export class GenericDatasource {
   cleanMatch(match: string, options: any) {
     const replacedMatch = this.templateSrv.replace(match, options.scopedVars, 'json');
     if (
-        typeof replacedMatch === 'string' &&
-        replacedMatch[0] === '"' && replacedMatch[replacedMatch.length - 1] === '"'
+        typeof replacedMatch === 'string'
+      &&
+        replacedMatch[0] === '"'
+      && replacedMatch[replacedMatch.length - 1] === '"'
     ) {
       return JSON.parse(replacedMatch);
     }


### PR DESCRIPTION
fixes https://github.com/simPod/grafana-json-datasource/issues/61

Unfortunately, after updating plugin from `0.1.4` to `0.1.5` variable interpolation is broken for JSON like `{"a": {"b": "$func"}}`. So this PR introduce changes:

1. rework to variable interpolation before `JSON.parse`
2. enable all variable templates that grafana support, e.g. `[[my_var]]`
