### PR TITLE
Partially revert "Pass target type to /search request (#55)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When adding datasource add your API endpoint to the `URL` field. That's where da
 To work with this datasource the backend needs to implement 4 urls:
 
 - `/` should return 200 ok. Used for "Test connection" on the datasource config page.
-- `/search` should return available metrics when invoked by the find metric options on the query tab in panels.
+- `/search` should return available metrics when invoked.
 - `/query` should return metrics based on input.
 - `/annotations` should return annotations.
 
@@ -54,6 +54,8 @@ Example request
 ``` json
 { "type": "timeseries", "target": "upper_50" }
 ```
+
+`type` is not always present.
 
 The search api can either return an array or map.
 

--- a/spec/datasource.jest.ts
+++ b/spec/datasource.jest.ts
@@ -63,7 +63,7 @@ describe('GenericDatasource', () => {
       return data;
     };
 
-    ctx.ds.findMetricsQuery('search', 'timeseries').then((result) => {
+    ctx.ds.metricFindQuery('search', 'timeseries').then((result) => {
       expect(result).toHaveLength(3);
       expect(result[0].text).toBe('search_0');
       expect(result[0].value).toBe('search_0');
@@ -91,7 +91,7 @@ describe('GenericDatasource', () => {
       return data;
     };
 
-    ctx.ds.findMetricsQuery('').then((result) => {
+    ctx.ds.metricFindQuery('').then((result) => {
       expect(result).toHaveLength(3);
       expect(result[0].text).toBe('metric_0');
       expect(result[0].value).toBe('metric_0');
@@ -119,7 +119,7 @@ describe('GenericDatasource', () => {
       return data;
     };
 
-    ctx.ds.findMetricsQuery().then((result) => {
+    ctx.ds.metricFindQuery().then((result) => {
       expect(result).toHaveLength(3);
       expect(result[0].text).toBe('metric_0');
       expect(result[0].value).toBe('metric_0');
@@ -146,7 +146,7 @@ describe('GenericDatasource', () => {
       return data;
     };
 
-    ctx.ds.findMetricsQuery('search', 'timeseries').then((result) => {
+    ctx.ds.metricFindQuery('search', 'timeseries').then((result) => {
       expect(result).toHaveLength(3);
       expect(result[0].text).toBe('search_0');
       expect(result[0].value).toBe('search_0');

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -92,7 +92,7 @@ export class GenericDatasource {
     });
   }
 
-  findMetricsQuery(query: string, type: string) {
+  metricFindQuery(query: string, options?: any, type?: string) {
     const interpolated = {
       type,
       target: this.templateSrv.replace(query, null, 'regex'),

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -25,7 +25,7 @@ export class GenericDatasourceQueryCtrl extends QueryCtrl {
   }
 
   findMetrics(query: string) {
-    return this.datasource.findMetricsQuery(query, this.target.type);
+    return this.datasource.metricFindQuery(query, undefined, this.target.type);
   }
 
   // not used


### PR DESCRIPTION
This partially reverts commit 62350157

We accidentally renamed `metricFindQuery()` and changed its signature.

Fixes #60