### PR TITLE
Fix README table example for "Expected response data to be array, got object"

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,19 +143,21 @@ _The relation between `target` in request and response is 1:n. You can return mu
 Example `table` response to be returned if the metric selected is `"type": "table"`:
 
 ``` json
-{
-  "columns":[
-    {"text":"Time","type":"time"},
-    {"text":"Country","type":"string"},
-    {"text":"Number","type":"number"}
-  ],
-  "rows":[
-    [1234567,"SE",123],
-    [1234567,"DE",231],
-    [1234567,"US",321]
-  ],
-  "type":"table"
-}
+[
+  {
+    "columns":[
+      {"text":"Time","type":"time"},
+      {"text":"Country","type":"string"},
+      {"text":"Number","type":"number"}
+    ],
+    "rows":[
+      [1234567,"SE",123],
+      [1234567,"DE",231],
+      [1234567,"US",321]
+    ],
+    "type":"table"
+  }
+]
 ```
 
 #### Additional data


### PR DESCRIPTION
Response for type table must be of type array.

See [original repository README.md example](https://github.com/grafana/simple-json-datasource/blob/9ede938338aff9c6c5d6af49c5c57dc62d91028b/README.md)

if the `[  ]` Array is omitted, Grafana `6.6.2` would return error `Expected response data to be array, got object`

![table-response](https://user-images.githubusercontent.com/33002073/76254781-5669ce80-624d-11ea-92dc-3ff55bcd1ab3.png)
