### PR TITLE
Increase the size of the CodeEditor used for additionalJsonData

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -8,6 +8,8 @@ import { Format } from './format';
 
 import { GenericOptions, GrafanaQuery } from './types';
 
+import './css/json-editor.css';
+
 type Props = QueryEditorProps<DataSource, GrafanaQuery, GenericOptions>;
 
 const formatAsOptions = [
@@ -134,10 +136,10 @@ export const QueryEditor: ComponentType<Props> = ({ datasource, onChange, onRunQ
         <div className="gf-form-label">
           <Label>Additional JSON Data</Label>
         </div>
-        <div className="gf-form">
+        <div className="gf-form grafana-json-datasource-editor">
           <CodeEditor
-            width="500px"
-            height="100px"
+            width="100%"
+            height="175px"
             language="json"
             showLineNumbers={true}
             showMiniMap={data.length > 100}

--- a/src/css/json-editor.css
+++ b/src/css/json-editor.css
@@ -1,0 +1,7 @@
+.grafana-json-datasource-editor {
+    width: 100%;
+}
+
+.grafana-json-datasource-editor div {
+    width: 100%;
+}


### PR DESCRIPTION
This pr should fix #125, those values felt like a good default to make the window a little bigger.

I didn't have time to test how it looks / if it works yet - i will be able to test that tomorrow, so i will leave it as a draft for now.