### PR TITLE
Set metric if it exists in the Panel JSON data

### DIFF
--- a/src/Component/QueryEditor.tsx
+++ b/src/Component/QueryEditor.tsx
@@ -1,6 +1,5 @@
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { CodeEditor, InlineField, InlineFieldRow, InlineLabel, Select } from '@grafana/ui';
-import { find } from 'lodash';
 
 import React, { ComponentType } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -29,11 +28,7 @@ export const QueryEditor: ComponentType<Props> = ({ datasource, onChange, onRunQ
       datasource.metricFindQuery({ query: '', format: 'string' }, undefined).then(
         (result) => {
           const metrics = result.map((value) => ({ label: value.text, value: value.value }));
-
-          const foundMetric = find(metrics, (metric) => metric.value === query.target);
-
-          setMetric(foundMetric === undefined ? { label: '', value: '' } : foundMetric);
-
+          if (query.target) setMetric({ label: query.label ?? query.target, value: query.target })
           return metrics;
         },
         (response) => {
@@ -71,7 +66,7 @@ export const QueryEditor: ComponentType<Props> = ({ datasource, onChange, onRunQ
 
     setLastQuery({ payload, metric: metric.value.toString() });
 
-    onChange({ ...query, payload, target: metric.value.toString() });
+    onChange({ ...query, payload, target: metric.value.toString(), label: metric.label?.toString() });
 
     onRunQuery();
   }, [payload, metric]);
@@ -82,6 +77,7 @@ export const QueryEditor: ComponentType<Props> = ({ datasource, onChange, onRunQ
         <InlineField>
           <Select
             isLoading={isMetricOptionsLoading}
+            width={24}
             prefix="Metric: "
             options={metricOptions}
             placeholder="Select metric"

--- a/src/Component/QueryEditor.tsx
+++ b/src/Component/QueryEditor.tsx
@@ -28,7 +28,7 @@ export const QueryEditor: ComponentType<Props> = ({ datasource, onChange, onRunQ
       datasource.metricFindQuery({ query: '', format: 'string' }, undefined).then(
         (result) => {
           const metrics = result.map((value) => ({ label: value.text, value: value.value }));
-          if (query.target) {
+          if (typeof query.target === 'string') {
             setMetric({ label: query.label ?? query.target, value: query.target });
           }
           return metrics;

--- a/src/Component/QueryEditor.tsx
+++ b/src/Component/QueryEditor.tsx
@@ -28,7 +28,9 @@ export const QueryEditor: ComponentType<Props> = ({ datasource, onChange, onRunQ
       datasource.metricFindQuery({ query: '', format: 'string' }, undefined).then(
         (result) => {
           const metrics = result.map((value) => ({ label: value.text, value: value.value }));
-          if (query.target) setMetric({ label: query.label ?? query.target, value: query.target })
+          if (query.target) {
+            setMetric({ label: query.label ?? query.target, value: query.target });
+          }
           return metrics;
         },
         (response) => {

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -97,7 +97,7 @@ export class DataSource extends DataSourceApi<GrafanaQuery, GenericOptions> {
         status: 'error',
         title: 'Error',
       };
-    } catch (err) {
+    } catch (err: any) {
       if (typeof err === 'string') {
         return {
           status: 'error',

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -17,6 +17,7 @@ export interface GrafanaQuery extends DataQuery {
   alias?: string;
   target?: string;
   payload: string;
+  label?: string;
 }
 
 export interface GenericOptions extends DataSourceJsonData {}


### PR DESCRIPTION
### Description

fixes #154 

I think we need to return control over the user interface to the client (Grafana). As a user we don't have metrics assigned by default, so it holds the placeholder value `Select metric`. With dropdown list we can select from fetched entries or provide a custom value, including template variables (`$project` in my case). Request validation in this case needs to be a part of server implementation. User in turn is expected to save valid settings to successfully restore on page reload, which seems to be a normal scenario.

In addition, we store text value in the Panel JSON for map(object) responses to restore it properly.


https://user-images.githubusercontent.com/18210256/144688351-83de61d4-3d04-45e5-9ef1-f2fda6ae95d3.mp4



