### PR TITLE
fix: update openapi.yaml to match changes from v0.3.0.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -109,7 +109,7 @@ paths:
                       type:
                         type: string
                         enum: ["timeseries", "table"]
-                      data:
+                      payload:
                         description: arbitrary "additional data" the user can pass in
                         type: object
                 scopedVars:


### PR DESCRIPTION
In v0.3.0, the data field was renamed to payload. This commit updates the OpenAPI spec to bring it up to date with that change.

Fixes #273 