### PR TITLE
fix: use scoped variables in the query builder

### DIFF
--- a/spec/lib/TemplateSrvStub.ts
+++ b/spec/lib/TemplateSrvStub.ts
@@ -1,26 +1,63 @@
-import { ScopedVars, TimeRange } from '@grafana/data';
+import { ScopedVars, TimeRange, TypedVariableModel, AdHocVariableFilter } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime/services/templateSrv';
-import template from 'lodash/template';
 
 export default class TemplateSrvStub implements TemplateSrv {
   containsTemplate(target?: string | undefined): boolean {
     throw new Error('Method not implemented.');
   }
+
   updateTimeRange(timeRange: TimeRange): void {
     throw new Error('Method not implemented.');
   }
+
   templateSettings = { interpolate: /\[\[([\s\S]+?)\]\]/g };
   data = {};
+  variables: TypedVariableModel[] | [] = [];
   adhocFilters = [];
   // tslint:disable-next-line:max-line-length
-  // https://github.com/grafana/grafana/blob/c1c0daa13d5951e3e13d46ef9467d9d832993fe5/public/app/features/variables/utils.ts#L23
+  // https://github.com/grafana/grafana/blob/ab5a3820d5fff4f0f042024b0aee0632e6a4ca08/public/app/features/variables/utils.ts#L24
+  /*
+   * This regex matches 3 types of variable reference with an optional format specifier
+   * There are 6 capture groups that replace will return
+   * \$(\w+)                                    $var1
+   * \[\[(\w+?)(?::(\w+))?\]\]                  [[var2]] or [[var2:fmt2]]
+   * \${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}   ${var3} or ${var3.fieldPath} or ${var3:fmt3} (or ${var3.fieldPath:fmt3} but that is not a separate capture group)
+   */
   regex = /\$(\w+)|\[\[(\w+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;
-  replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
-    return template(target, this.templateSettings)(this.data);
+
+  // from: https://github.com/grafana/grafana/blob/ab5a3820d5fff4f0f042024b0aee0632e6a4ca08/public/app/features/templating/template_srv.mock.ts#L30
+  // Adjusted for use of scoped variables, and ad hoc filters.
+  replace(target?: string, scopedVars?: ScopedVars): string {
+    if (!target) {
+      return target ?? '';
+    }
+    this.regex.lastIndex = 0;
+
+    return target.replace(this.regex, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
+      const variableName = var1 || var2 || var3;
+      const variable: TypedVariableModel | undefined = this.variables.find(
+        (variable: TypedVariableModel) => variable.name === variableName,
+        {}
+      );
+      if (!variable) {
+        return 'unknown variable';
+      }
+      // AdHoc filters or other variable.
+      let value =
+        'filters' in variable
+          ? variable.filters.map((filter: AdHocVariableFilter) => filter.value)
+          : variable.current.value;
+
+      if (scopedVars && scopedVars[variable.name]) {
+        value = scopedVars[variable.name].value;
+      }
+
+      return value;
+    });
   }
 
-  getVariables() {
-    return [];
+  getVariables(): TypedVariableModel[] {
+    return this.variables;
   }
 
   getAdhocFilters(datasourceName: string) {

--- a/spec/lib/TemplateSrvStub.ts
+++ b/spec/lib/TemplateSrvStub.ts
@@ -48,7 +48,7 @@ export default class TemplateSrvStub implements TemplateSrv {
           ? variable.filters.map((filter: AdHocVariableFilter) => filter.value)
           : variable.current.value;
 
-      if (scopedVars?.scopedVars[variable.name] !== undefined) {
+      if (scopedVars?.[variable.name] !== undefined) {
         value = scopedVars[variable.name].value;
       }
 

--- a/spec/lib/TemplateSrvStub.ts
+++ b/spec/lib/TemplateSrvStub.ts
@@ -28,7 +28,7 @@ export default class TemplateSrvStub implements TemplateSrv {
   // from: https://github.com/grafana/grafana/blob/ab5a3820d5fff4f0f042024b0aee0632e6a4ca08/public/app/features/templating/template_srv.mock.ts#L30
   // Adjusted for use of scoped variables, and ad hoc filters.
   replace(target?: string, scopedVars?: ScopedVars): string {
-    if (!target) {
+    if (target === undefined) {
       return target ?? '';
     }
     this.regex.lastIndex = 0;
@@ -39,7 +39,7 @@ export default class TemplateSrvStub implements TemplateSrv {
         (variable: TypedVariableModel) => variable.name === variableName,
         {}
       );
-      if (!variable) {
+      if (variable === undefined) {
         return 'unknown variable';
       }
       // AdHoc filters or other variable.
@@ -48,7 +48,7 @@ export default class TemplateSrvStub implements TemplateSrv {
           ? variable.filters.map((filter: AdHocVariableFilter) => filter.value)
           : variable.current.value;
 
-      if (scopedVars && scopedVars[variable.name]) {
+      if (scopedVars?.scopedVars[variable.name] !== undefined) {
         value = scopedVars[variable.name].value;
       }
 

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -261,9 +261,9 @@ export class DataSource extends DataSourceApi<GrafanaQuery, GenericOptions> {
           if (Object.prototype.hasOwnProperty.call(newPayload, key)) {
             const value = newPayload[key];
             if (isArray(value)) {
-              newPayload[key] = value.map((item) => getTemplateSrv().replace(item.toString(), undefined, 'regex'));
+              newPayload[key] = value.map((item) => getTemplateSrv().replace(item.toString(), scopedVars, 'regex'));
             } else {
-              newPayload[key] = getTemplateSrv().replace(newPayload[key].toString(), undefined, 'regex');
+              newPayload[key] = getTemplateSrv().replace(newPayload[key].toString(), scopedVars, 'regex');
             }
           }
         }


### PR DESCRIPTION
When using repeated variables via the query builder, all multi-value variables were sent from each panel instead of using the scoped variables. This is the simple fix for that.