### PR TITLE
Extension: add forward fill option

### DIFF
--- a/src/Component/QueryBuilder.tsx
+++ b/src/Component/QueryBuilder.tsx
@@ -8,6 +8,7 @@ import { EditorField, EditorFieldGroup } from '@grafana/experimental';
 import { QueryBuilderTextArea } from './QueryBuilderTextArea';
 import { QueryBuilderPayloadSelect } from './QueryBuilderPayloadSelect';
 import { QueryBuilderTag } from './QueryBuilderTag';
+import QueryBuilderOptions, { AVAILABLE_OPTIONS } from './QueryBuilderOptions';
 
 interface LastQuery {
   payload: string | { [key: string]: any };
@@ -87,7 +88,8 @@ export const QueryBuilder: ComponentType<Props> = (props) => {
     const newUnknownPayload: UnknownPayload = [];
     for (const key in payload) {
       const foundConfig = payloadConfig.find((item) => item.name === key);
-      if (foundConfig === undefined) {
+      const foundAvailableOption = AVAILABLE_OPTIONS.find((item) => item === key);
+      if (foundConfig === undefined && foundAvailableOption === undefined) {
         newUnknownPayload.push({ name: key, value: payload[key] });
       }
 
@@ -98,7 +100,7 @@ export const QueryBuilder: ComponentType<Props> = (props) => {
   const changePayload = (
     name: string,
     reloadMetric?: boolean,
-    v?: SelectableValue<string | number> | Array<SelectableValue<string | number>>
+    v?: SelectableValue<string | number | boolean> | Array<SelectableValue<string | number | boolean>>
   ) => {
     setPayload((ori) => {
       let newPayload: { [key: string]: any } = { ...ori };
@@ -135,6 +137,7 @@ export const QueryBuilder: ComponentType<Props> = (props) => {
       return newPayload;
     });
   };
+
   return (
     <>
       <EditorFieldGroup>
@@ -156,6 +159,7 @@ export const QueryBuilder: ComponentType<Props> = (props) => {
           />
         </EditorField>
       </EditorFieldGroup>
+      <QueryBuilderOptions payload={payload} onChange={changePayload} />
       {payloadConfig.length > 0 && (
         <EditorFieldGroup>
           <EditorField label="Payload" style={{ width: '100%' }}>

--- a/src/Component/QueryBuilderOptions.tsx
+++ b/src/Component/QueryBuilderOptions.tsx
@@ -1,0 +1,37 @@
+import { SelectableValue } from '@grafana/data';
+import { Field, HorizontalGroup, InlineField, InlineSwitch } from '@grafana/ui';
+import React, { useState } from 'react';
+
+interface QueryBuilderOptionsProps {
+    payload: { [key: string]: unknown };
+    onChange: (
+        name: string,
+        reloadMetric?: boolean,
+        v?: SelectableValue<string | number | boolean> | Array<SelectableValue<string | number | boolean>>
+    ) => void;
+}
+
+const QueryBuilderOptions = (props: QueryBuilderOptionsProps) => {
+    const [forwardFill, setForwardFill] = useState<boolean>(false);
+
+    const changeForwardFill = (v: React.FormEvent<HTMLInputElement>) => {
+        setForwardFill(v.currentTarget.checked);
+        props.onChange('forward_fill', false, { value: v.currentTarget.checked });
+    };
+
+    return (
+        <div style={{ marginTop: '18px' }}>
+            <HorizontalGroup justify="flex-start" spacing="sm">
+                <Field label="Options">
+                    <InlineField label="Forward-Fill">
+                        <InlineSwitch value={forwardFill} disabled={false} transparent={false} onChange={changeForwardFill} />
+                    </InlineField>
+                </Field>
+            </HorizontalGroup>
+        </div>
+    );
+};
+
+export const AVAILABLE_OPTIONS = ['forward_fill'];
+
+export default QueryBuilderOptions;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,15 @@
 {
     "extends": "./node_modules/@grafana/toolkit/src/config/tsconfig.plugin.json",
-    "include": ["src", "types"],
+    "include": [
+        "src",
+        "types"
+    ],
     "compilerOptions": {
+        "jsx": "react",
         "rootDir": "./src",
         "baseUrl": "./src",
-        "typeRoots": ["./node_modules/@types"]
+        "typeRoots": [
+            "./node_modules/@types"
+        ]
     }
 }


### PR DESCRIPTION
Hey guys,
we had some use-cases where we needed to interpolate the values between two data points in a time series by filling in the values from the first data point until the timestamp of the second one was reached. For that we implemented a simple toggle in the UI which forwards that info as payload to the data source. We now just want to share this with the open source community.