### PR TITLE
fix:when target is hide, not request with it

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -57,6 +57,8 @@ export class DataSource extends DataSourceApi<GrafanaQuery, GenericOptions> {
   query(options: QueryRequest): Promise<DataQueryResponse> {
     const request = this.processTargets(options);
 
+    request.targets = request.targets.filter((t) => !t.hide);
+
     if (request.targets.length === 0) {
       return Promise.resolve({ data: [] });
     }


### PR DESCRIPTION
There is one bug, when I use the plugins to show graph. Plugins default use all targets to request even through the target is hide. Below is some picture to show this problem.

old code will ignore the hide state change.
![fix-target-hide1](https://github.com/simPod/GrafanaJsonDatasource/assets/26199175/341d6e8e-e40c-4c15-9f3e-0230216ddede)

![fix-target-hide2](https://github.com/simPod/GrafanaJsonDatasource/assets/26199175/cc3301f7-3fe8-4a6b-ab5b-aaaab6d05a89)

after code commit
![fix-target-hide3](https://github.com/simPod/GrafanaJsonDatasource/assets/26199175/a7b94601-6839-422e-a087-ada7f00e827d)

![fix-target-hide4](https://github.com/simPod/GrafanaJsonDatasource/assets/26199175/9d01a9ba-c979-4fe8-af99-113127778e46)

![fix-target-hide5](https://github.com/simPod/GrafanaJsonDatasource/assets/26199175/ba42514f-5fb9-4e67-8ef0-c2a93037d01b)
