### PR TITLE
chore: remove broken licence link from plugin.json

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -22,10 +22,6 @@
             {
                 "name": "GitHub",
                 "url": "https://github.com/simPod/grafana-json-datasource"
-            },
-            {
-                "name": "MIT License",
-                "url": "https://github.com/simPod/grafana-json-datasource/blob/master/LICENSE"
             }
         ],
         "screenshots": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the "MIT License" link from the plugin information. The "GitHub" link remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->