### PR TITLE
fix: parse custom and query variables using our special function

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -29,6 +29,8 @@ import {
 import { VariableSupport } from './variable/VariableSupport';
 import { doFetch } from './doFetch';
 import { MetricFindQuery } from './MetricFindQuery';
+import { match, P } from 'ts-pattern';
+import { valueFromVariableWithMultiSupport } from './variable/valueFromVariableWithMultiSupport';
 
 export class DataSource extends DataSourceApi<GrafanaQuery, GenericOptions> {
   url: string;
@@ -305,7 +307,12 @@ export class DataSource extends DataSourceApi<GrafanaQuery, GenericOptions> {
         return;
       }
 
-      const value = getTemplateSrv().replace('$' + variable.name, scopedVars, 'json');
+      const value = match(variable)
+        .with({ type: P.union('custom', 'query') }, (v) => valueFromVariableWithMultiSupport(v))
+        .with({ type: P.union('constant', 'datasource', 'groupby', 'interval', 'snapshot', 'textbox') }, (v) =>
+          getTemplateSrv().replace('$' + variable.name, scopedVars, 'json')
+        )
+        .exhaustive();
 
       variableOptions[variable.name] = {
         text: variable.current.text,

--- a/src/variable/valueFromVariableWithMultiSupport.ts
+++ b/src/variable/valueFromVariableWithMultiSupport.ts
@@ -1,0 +1,23 @@
+import { VariableWithMultiSupport } from '@grafana/data';
+import { isEqual } from 'lodash';
+
+export const valueFromVariableWithMultiSupport = (variable: VariableWithMultiSupport) => {
+  let variableValue = variable.current.value;
+  if (variableValue === '$__all' || isEqual(variableValue, ['$__all'])) {
+    if (variable.allValue === null || variable.allValue === '' || variable.allValue === undefined) {
+      variableValue = variable.options.slice(1).map((variableOption) => {
+        if (typeof variableOption.value !== 'string') {
+          const error = new Error('Variable option value is not a string');
+          console.error(error.message, variableOption, variable);
+
+          throw error;
+        }
+        return variableOption.value;
+      });
+    } else {
+      variableValue = variable.allValue;
+    }
+  }
+
+  return variableValue;
+};


### PR DESCRIPTION
When e.g. PG query returns list of values, it cannot be interpolated as array via templateSrv.replace().

```
values: [
  [
    1,
    2,
    3
  ]
]
```

we need to pass such array of values as `[1, 2, 3]`.

replace() as json passes it as json string `"[1,2,3]"`. replace() as is passes it as `{1,2,3}` string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of variables with multi-select support for more accurate value resolution.

* **Bug Fixes**
  * Enhanced reliability when processing variables with special "all" selections to prevent errors and ensure correct values are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->